### PR TITLE
Add Discord channel ID matching (PR #187) and tests for it

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -154,7 +154,7 @@ class Bot {
     if (author.id === this.discord.user.id) return;
 
     const channelName = `#${message.channel.name}`;
-    const ircChannel = this.channelMapping[channelName];
+    const ircChannel = this.channelMapping[message.channel.id in this.channelMapping ? message.channel.id : channelName];
 
     logger.debug('Channel Mapping', channelName, this.channelMapping[channelName]);
     if (ircChannel) {
@@ -193,9 +193,9 @@ class Bot {
     const discordChannelName = this.invertedMapping[channel.toLowerCase()];
     if (discordChannelName) {
       // #channel -> channel before retrieving and select only text channels:
-      const discordChannel = this.discord.channels
+      const discordChannel = discordChannelName.charAt(0) == '#' ? this.discord.channels
         .filter(c => c.type === 'text')
-        .find('name', discordChannelName.slice(1));
+        .find('name', discordChannelName.slice(1)) : this.discord.channels.get(discordChannelName);
 
       if (!discordChannel) {
         logger.info('Tried to send a message to a channel the bot isn\'t in: ',

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -154,7 +154,7 @@ class Bot {
     if (author.id === this.discord.user.id) return;
 
     const channelName = `#${message.channel.name}`;
-    const ircChannel = this.channelMapping[message.channel.id] || 
+    const ircChannel = this.channelMapping[message.channel.id] ||
                                            this.channelMapping[channelName];
 
     logger.debug('Channel Mapping', channelName, this.channelMapping[channelName]);

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -154,7 +154,8 @@ class Bot {
     if (author.id === this.discord.user.id) return;
 
     const channelName = `#${message.channel.name}`;
-    const ircChannel = this.channelMapping[message.channel.id in this.channelMapping ? message.channel.id : channelName];
+    const ircChannel = this.channelMapping[message.channel.id in this.channelMapping ?
+                                           message.channel.id : channelName];
 
     logger.debug('Channel Mapping', channelName, this.channelMapping[channelName]);
     if (ircChannel) {
@@ -193,7 +194,7 @@ class Bot {
     const discordChannelName = this.invertedMapping[channel.toLowerCase()];
     if (discordChannelName) {
       // #channel -> channel before retrieving and select only text channels:
-      const discordChannel = discordChannelName.charAt(0) == '#' ? this.discord.channels
+      const discordChannel = discordChannelName.charAt(0) === '#' ? this.discord.channels
         .filter(c => c.type === 'text')
         .find('name', discordChannelName.slice(1)) : this.discord.channels.get(discordChannelName);
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -154,8 +154,8 @@ class Bot {
     if (author.id === this.discord.user.id) return;
 
     const channelName = `#${message.channel.name}`;
-    const ircChannel = this.channelMapping[message.channel.id in this.channelMapping ?
-                                           message.channel.id : channelName];
+    const ircChannel = this.channelMapping[message.channel.id] || 
+                                           this.channelMapping[channelName];
 
     logger.debug('Channel Mapping', channelName, this.channelMapping[channelName]);
     if (ircChannel) {
@@ -194,7 +194,7 @@ class Bot {
     const discordChannelName = this.invertedMapping[channel.toLowerCase()];
     if (discordChannelName) {
       // #channel -> channel before retrieving and select only text channels:
-      const discordChannel = discordChannelName.charAt(0) === '#' ? this.discord.channels
+      const discordChannel = discordChannelName.startsWith('#') ? this.discord.channels
         .filter(c => c.type === 'text')
         .find('name', discordChannelName.slice(1)) : this.discord.channels.get(discordChannelName);
 

--- a/test/channel-mapping.test.js
+++ b/test/channel-mapping.test.js
@@ -46,4 +46,10 @@ describe('Channel Mapping', () => {
     bot.channelMapping['#discord'].should.equal('#irc');
     bot.channelMapping['#otherDiscord'].should.equal('#otherirc');
   });
+
+  it('should work with ID maps', () => {
+    const bot = new Bot(config);
+    bot.channelMapping['1234'].should.equal('#channelforid');
+    bot.invertedMapping['#channelforid'].should.equal('1234');
+  });
 });

--- a/test/channel-mapping.test.js
+++ b/test/channel-mapping.test.js
@@ -38,7 +38,7 @@ describe('Channel Mapping', () => {
     const bot = new Bot(config);
     bot.channelMapping['#discord'].should.equal('#irc');
     bot.invertedMapping['#irc'].should.equal('#discord');
-    bot.channels[0].should.equal('#irc channelKey');
+    bot.channels.should.contain('#irc channelKey');
   });
 
   it('should lowercase IRC channel names', () => {

--- a/test/fixtures/single-test-config.json
+++ b/test/fixtures/single-test-config.json
@@ -9,6 +9,7 @@
   ],
   "channelMapping": {
     "#discord": "#irc channelKey",
-    "#notinchannel": "#otherIRC"
+    "#notinchannel": "#otherIRC",
+    "1234": "#channelforid"
   }
 }


### PR DESCRIPTION
Builds on PR #187 (credit to @mraof for adding in the actual change to the code). This adds tests, where I think they're supposed to be? It doesn't actually test that Discord – or whatever library you're using – supports IDs in its API, but this seems to work when I use them in my own config, and these tests should ensure the bot's code itself has no trouble with the IDs. (IDs can be retrieved by writing, e.g., `\#general`, which should produce something of the form `<#00000000>`. Remove the `<#` and `>` and use that in the config.)

Commit 2ae9e37 was added since the previous check seems to break with this new addition to the config file – it seems to be related to how the items are ordered in the hash and so how they get added to the `channels` list, which I'm pretty sure isn't *important* anywhere, so I modified it to a check for presence instead of a check that the first item in the list is precisely that.